### PR TITLE
Added MSYS2 ci, Included shaders into artifacts.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,30 +42,6 @@ jobs:
           ./build.sh
         env:
           CC: clang
-  build-windows-msvc:
-    runs-on: windows-2019
-    steps:
-      - uses: actions/checkout@v1
-        # this runs vcvarsall for us, so we get the MSVC toolchain in PATH.
-      - uses: seanmiddleditch/gha-setup-vsdevenv@master
-      - name: Install dependencies
-        run: |
-          ./setup_dependencies.bat
-      - name: build ded
-        shell: cmd
-        run: |
-          ./build_msvc.bat
-      - name: Prepare WindowsBinaries artifacts
-        shell: cmd
-        run: |
-          mkdir winbin
-          copy /B *.exe winbin
-          copy /B *.png winbin
-      - name: Upload WindowsBinaries artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: WindowsBinaries
-          path: ./winbin/
   build-windows-msys2:
     runs-on: windows-2019
     steps:
@@ -89,11 +65,37 @@ jobs:
       - name: Prepare Windows_MSYS2_Binaries artifacts
         shell: cmd
         run: |
-          mkdir winbin
+          mkdir winbin\shaders
           copy /B *.exe winbin
           copy /B *.png winbin
+          copy /B shaders\*.* winbin\shaders
       - name: Upload Windows_MSYS2_Binaries artifacts
         uses: actions/upload-artifact@v2
         with:
           name: Windows_MSYS2_Binaries
+          path: ./winbin/
+  build-windows-msvc:
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v1
+        # this runs vcvarsall for us, so we get the MSVC toolchain in PATH.
+      - uses: seanmiddleditch/gha-setup-vsdevenv@master
+      - name: Install dependencies
+        run: |
+          ./setup_dependencies.bat
+      - name: build ded
+        shell: cmd
+        run: |
+          ./build_msvc.bat
+      - name: Prepare WindowsBinaries artifacts
+        shell: cmd
+        run: |
+          mkdir winbin\shaders
+          copy /B *.exe winbin
+          copy /B *.png winbin
+          copy /B shaders\*.* winbin\shaders
+      - name: Upload WindowsBinaries artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: WindowsBinaries
           path: ./winbin/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,3 +66,34 @@ jobs:
         with:
           name: WindowsBinaries
           path: ./winbin/
+  build-windows-msys2:
+    runs-on: windows-2019
+    steps:
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MSYS
+          path-type: minimal
+          install: >-
+            git
+            base-devel
+            mingw-w64-i686-gcc
+            mingw-w64-i686-glew
+            mingw-w64-i686-mesa
+            mingw-w64-i686-SDL2
+            mingw-w64-i686-pkg-config
+      - uses: actions/checkout@v1
+      - name: build ded
+        shell: msys2 {0}
+        run: |
+          ./build.sh --static "-static -lopengl32"
+      - name: Prepare Windows_MSYS2_Binaries artifacts
+        shell: cmd
+        run: |
+          mkdir winbin
+          copy /B *.exe winbin
+          copy /B *.png winbin
+      - name: Upload Windows_MSYS2_Binaries artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: Windows_MSYS2_Binaries
+          path: ./winbin/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - uses: msys2/setup-msys2@v2
         with:
-          msystem: MSYS
+          msystem: MINGW32
           path-type: minimal
           install: >-
             git

--- a/build.sh
+++ b/build.sh
@@ -3,13 +3,13 @@
 set -xe
 
 CC="${CXX:-cc}"
-PKGS="sdl2 glew"
+PKGS="$1 sdl2 glew"
 CFLAGS="-Wall -Wextra -std=c11 -pedantic -ggdb"
-LIBS=-lm
+LIBS="-lm $2"
 SRC="src/main.c src/la.c src/editor.c src/sdl_extra.c src/file.c src/gl_extra.c"
 
 if [ `uname` = "Darwin" ]; then
     CFLAGS+=" -framework OpenGL"
 fi
 
-$CC $CFLAGS `pkg-config --cflags $PKGS` -o ded $SRC $LIBS `pkg-config --libs $PKGS`
+$CC $CFLAGS `pkg-config --cflags $PKGS` -o ded $SRC $LIBS `pkg-config --libs $PKGS` $LIBS `pkg-config --libs $PKGS`


### PR DESCRIPTION
MSYS2 executable is awesome, cuz SDL2.dll is not needed.
MSYS2 ci utilizes `build.sh` with parameters : `./build.sh --static "-static -lopengl32"`.
Linux ci works same as before.