### PR TITLE
Fix Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ```console
 $ ./build.sh
-$ ./ded src\main.c
+$ ./ded src/main.c
 ```
 
 ## Windows MSVC


### PR DESCRIPTION
POSIX uses forward slashes as a path separator.