### PR TITLE
sh script to compile in windows executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ $ ./ded src\main.c
 > .\ded.exe src\main.c
 ```
 
+## msys2 in windows
+you can use msys2 and mingw64 for build this app into native windows exe. 
+Run `mingw64.exe` after msys2 installation.
+Add packaged into it: `pacman -S git base-devel mingw-w64-x86_64-gcc mingw-w64-x86_64-glew mingw-w64-x86_64-mesa mingw-w64-x86_64-SDL2 mingw-w64-x86_64-pkgconf mingw-w64-x86_64-freetype`
+Change dir by `cd "path_copypasted_from_explorer_without_final_slash"`
+Run script `./build_msys2_mingw64.sh`. The resulting `life.exe` is 6 MB in size.
+
+
 # Font
 
 Victor Mono: https://rubjo.github.io/victor-mono/

--- a/build_msys2_mingw64.sh
+++ b/build_msys2_mingw64.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -xe
+
+PKGS="--static sdl2 glew freetype2"
+CFLAGS="-Wall -Wextra -pedantic -ggdb -DGLEW_STATIC `pkg-config --cflags $PKGS`"
+LIBS="-lm -lopengl32 `pkg-config --libs $PKGS`"
+SRC="src/main.c src/la.c src/editor.c src/sdl_extra.c src/file.c src/gl_extra.c src/free_glyph.c src/uniforms.c src/simple_renderer.c"
+OBJ=$(echo "$SRC" | sed "s/\.c/\.o/g")
+OBJ=$(echo "$OBJ" | sed "s/src\// /g")
+
+gcc -std=c11 $CFLAGS -c $SRC
+# some libs linked with c++ stuff
+g++ -o life.exe $OBJ $LIBS $LIBS -static
+


### PR DESCRIPTION
Here is a script to compile in windows executable. Runs in the shell "mingw64.exe" from the MSYS2 package. The resulting `life.exe` is 6 MB in size. It runs separately (static) and allows to print rainbow letters.