### PR TITLE
Added indentation with the tab key

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -35,6 +35,13 @@ void editor_delete(Editor *e)
     editor_recompute_lines(e);
 }
 
+void editor_tab(Editor *e)
+{
+    for(int i = 0; i < 4; i++) {
+        editor_insert_char(e, ' ');
+    }
+}
+
 void editor_save_to_file(const Editor *editor, const char *file_path)
 {
     FILE *f = fopen(file_path, "w");

--- a/src/editor.h
+++ b/src/editor.h
@@ -44,6 +44,7 @@ void editor_load_from_file(Editor *editor, FILE *file);
 
 void editor_backspace(Editor *editor);
 void editor_delete(Editor *editor);
+void editor_tab(Editor *editor);
 size_t editor_cursor_row(const Editor *e);
 void editor_move_line_up(Editor *e);
 void editor_move_line_down(Editor *e);

--- a/src/main.c
+++ b/src/main.c
@@ -291,6 +291,12 @@ int main(int argc, char **argv)
                 }
                 break;
 
+                case SDLK_TAB: {
+                    editor_tab(&editor);
+                    last_stroke = SDL_GetTicks();
+                }
+                break;
+
                 case SDLK_UP: {
                     editor_move_line_up(&editor);
                     last_stroke = SDL_GetTicks();


### PR DESCRIPTION
Whenever the tab key is pressed, a 4-space indentation is inserted, in a similar manner to most editors