### PR TITLE
sh script to compile editor (with F3 capability) in windows executable

### DIFF
--- a/build_msys2_mingw64.sh
+++ b/build_msys2_mingw64.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -xe
+
+PKGS="--static sdl2 glew freetype2"
+CFLAGS="-Wall -Wextra -pedantic -ggdb -DGLEW_STATIC `pkg-config --cflags $PKGS` -Isrc -Dassert(expression)=((void)0) "
+LIBS="-lm -lopengl32 `pkg-config --libs $PKGS`"
+SRC="src/main.c src/la.c src/editor.c src/file_browser.c src/free_glyph.c src/simple_renderer.c src/common.c"
+OBJ=$(echo "$SRC" | sed "s/\.c/\.o/g")
+OBJ=$(echo "$OBJ" | sed "s/src\// /g")
+
+# wget "https://raw.githubusercontent.com/tsoding/minirent/master/minirent.h" -P /src
+gcc -std=c11 $CFLAGS -c $SRC
+# some libs linked with c++ stuff
+g++ -o life.exe $OBJ $LIBS $LIBS -static
+


### PR DESCRIPTION
Here is a script to compile Editor in windows executable. Runs in the shell "mingw64.exe" from the MSYS2 package. The resulting `life.exe` is 6 MB in size.

## manual for msys2 in windows
Run `mingw64.exe` after msys2 installation.
Add packaged into it: `pacman -S git base-devel mingw-w64-x86_64-gcc mingw-w64-x86_64-glew mingw-w64-x86_64-mesa mingw-w64-x86_64-SDL2 mingw-w64-x86_64-pkgconf mingw-w64-x86_64-freetype`
Change dir by `cd "path_copypasted_from_explorer_without_final_slash"`
Run script `./build_msys2_mingw64.sh`. The resulting `life.exe` is 6 MB in size.
 It runs separately (static) and allows to print rainbow letters. 
Press F3 for directory browsing.