### PR TITLE
Two trivial improvements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ $ ./build.sh
 $ ./ded src\main.c
 ```
 
+### Debian / Ubuntu / Linux Mint dependencies
+
+```console
+$ sudo apt install libsdl2-dev libglew-dev libfreetype-dev
+```
+
+If you get an error like "Package 'opengl', required by 'glu', not found", install `libopengl-dev`.
+
 ## Windows MSVC
 
 ```console

--- a/build.sh
+++ b/build.sh
@@ -7,9 +7,10 @@ PKGS="sdl2 glew freetype2"
 CFLAGS="-Wall -Wextra -std=c11 -pedantic -ggdb"
 LIBS=-lm
 SRC="src/main.c src/la.c src/editor.c src/file_browser.c src/free_glyph.c src/simple_renderer.c src/common.c src/lexer.c"
+PKG_CFLAGS=`pkg-config --cflags $PKGS`
 
 if [ `uname` = "Darwin" ]; then
     CFLAGS+=" -framework OpenGL"
 fi
 
-$CC $CFLAGS `pkg-config --cflags $PKGS` -o ded $SRC $LIBS `pkg-config --libs $PKGS`
+$CC $CFLAGS $PKG_CFLAGS -o ded $SRC $LIBS `pkg-config --libs $PKGS`


### PR DESCRIPTION
Document linux debian/ubuntu/mint dependencies in README.
Uninline `pkg-config` call in `build.sh` for reasons mentioned in #52
