### PR TITLE
Fix error message typos, consistent messages

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -60,7 +60,7 @@ int main(int argc, char **argv)
 
     FT_Error error = FT_Init_FreeType(&library);
     if (error) {
-        fprintf(stderr, "ERROR: could initialize FreeType2 library\n");
+        fprintf(stderr, "ERROR: Could not initialize FreeType2 library\n");
         return 1;
     }
 
@@ -74,7 +74,7 @@ int main(int argc, char **argv)
         fprintf(stderr, "ERROR: `%s` has an unknown format\n", font_file_path);
         return 1;
     } else if (error) {
-        fprintf(stderr, "ERROR: could not load file `%s`\n", font_file_path);
+        fprintf(stderr, "ERROR: Could not load file `%s`\n", font_file_path);
         return 1;
     }
 
@@ -83,7 +83,7 @@ int main(int argc, char **argv)
     // We need to use something like FT_Set_Char_Size and properly set the device resolution
     error = FT_Set_Pixel_Sizes(face, 0, pixel_size);
     if (error) {
-        fprintf(stderr, "ERROR: could not set pixel size to %u\n", pixel_size);
+        fprintf(stderr, "ERROR: Could not set pixel size to %u\n", pixel_size);
         return 1;
     }
 
@@ -91,7 +91,7 @@ int main(int argc, char **argv)
         const char *file_path = argv[1];
         err = editor_load_from_file(&editor, file_path);
         if (err != 0) {
-            fprintf(stderr, "ERROR: Could ont read file %s: %s\n", file_path, strerror(err));
+            fprintf(stderr, "ERROR: Could not read file %s: %s\n", file_path, strerror(err));
             return 1;
         }
     }
@@ -131,12 +131,12 @@ int main(int argc, char **argv)
     }
 
     if (SDL_GL_CreateContext(window) == NULL) {
-        fprintf(stderr, "Could not create OpenGL context: %s\n", SDL_GetError());
+        fprintf(stderr, "ERROR: Could not create OpenGL context: %s\n", SDL_GetError());
         return 1;
     }
 
     if (GLEW_OK != glewInit()) {
-        fprintf(stderr, "Could not initialize GLEW!");
+        fprintf(stderr, "ERROR: Could not initialize GLEW!");
         return 1;
     }
 
@@ -157,7 +157,7 @@ int main(int argc, char **argv)
         glEnable(GL_DEBUG_OUTPUT);
         glDebugMessageCallback(MessageCallback, 0);
     } else {
-        fprintf(stderr, "WARNING! GLEW_ARB_debug_output is not available");
+        fprintf(stderr, "WARNING: GLEW_ARB_debug_output is not available");
     }
 
     simple_renderer_init(&sr);


### PR DESCRIPTION
Also made some a bit more consistent with the norm format-wise.  (no code/logic changes, only edited some strings that get output on errors/warnings) (Capitalized, etc.)