### PR TITLE
Distance field font rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 # Quick Start
 
+## Dependencies
+
+- [SDL2 2.0.9+](https://www.libsdl.org/)
+- [FreeType 2.13.0+](https://freetype.org/)
+- [GLEW 2.1.0+](https://glew.sourceforge.net/)
+
 ## POSIX
 
 ```console

--- a/shaders/simple_epic.frag
+++ b/shaders/simple_epic.frag
@@ -13,7 +13,10 @@ vec3 hsl2rgb(vec3 c) {
 
 void main() {
     vec4 tc = texture(image, out_uv);
+    float d = tc.r;
+    float aaf = fwidth(d);
+    float alpha = smoothstep(0.5 - aaf, 0.5 + aaf, d);
     vec2 frag_uv = gl_FragCoord.xy / resolution;
     vec4 rainbow = vec4(hsl2rgb(vec3((time + frag_uv.x + frag_uv.y), 0.5, 0.5)), 1.0);
-    gl_FragColor = tc.x * rainbow;
+    gl_FragColor = vec4(rainbow.rgb, alpha);
 }

--- a/shaders/simple_text.frag
+++ b/shaders/simple_text.frag
@@ -6,5 +6,8 @@ in vec4 out_color;
 in vec2 out_uv;
 
 void main() {
-    gl_FragColor = texture(image, out_uv).x*out_color;
+    float d = texture(image, out_uv).r;
+    float aaf = fwidth(d);
+    float alpha = smoothstep(0.5 - aaf, 0.5 + aaf, d);
+    gl_FragColor = vec4(out_color.rgb, alpha);
 }

--- a/src/free_glyph.c
+++ b/src/free_glyph.c
@@ -4,8 +4,9 @@
 
 void free_glyph_atlas_init(Free_Glyph_Atlas *atlas, FT_Face face)
 {
+    FT_Int32 load_flags = FT_LOAD_RENDER | FT_LOAD_TARGET_(FT_RENDER_MODE_SDF);
     for (int i = 32; i < 128; ++i) {
-        if (FT_Load_Char(face, i, FT_LOAD_RENDER)) {
+        if (FT_Load_Char(face, i, load_flags)) {
             fprintf(stderr, "ERROR: could not load glyph of a character with code %d\n", i);
             exit(1);
         }
@@ -39,7 +40,7 @@ void free_glyph_atlas_init(Free_Glyph_Atlas *atlas, FT_Face face)
 
     int x = 0;
     for (int i = 32; i < 128; ++i) {
-        if (FT_Load_Char(face, i, FT_LOAD_RENDER)) {
+        if (FT_Load_Char(face, i, load_flags)) {
             fprintf(stderr, "ERROR: could not load glyph of a character with code %d\n", i);
             exit(1);
         }


### PR DESCRIPTION
Using freetype's built in signed distance field flags to render text with anti aliasing. Note that in this case sub-pixel antialiasing is still not implemented which results in subtle visual errors when the text is scrolling at smaller scales.

![screenshot-2](https://user-images.githubusercontent.com/14351670/217992687-0e16d2a6-4ed2-4da6-8078-bc24a337e5f9.png)
![screenshot-1](https://user-images.githubusercontent.com/14351670/217992692-0d79993f-c61b-4d09-bbde-c9352be3ea22.png)
