### PR TITLE
Fix cursor misaligned: add cursor offset

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -10,6 +10,7 @@
 #define SCREEN_HEIGHT 600
 #define FPS 60
 #define DELTA_TIME (1.0f / FPS)
+#define CURSOR_OFFSET 0.13f
 
 typedef int Errno;
 

--- a/src/editor.c
+++ b/src/editor.c
@@ -235,7 +235,7 @@ void editor_render(SDL_Window *window, Free_Glyph_Atlas *atlas, Simple_Renderer 
                 }
 
                 if (select_begin_chr <= select_end_chr) {
-                    Vec2f select_begin_scr = vec2f(0, -(float)row * FREE_GLYPH_FONT_SIZE);
+                    Vec2f select_begin_scr = vec2f(0, -((float)row + CURSOR_OFFSET) * FREE_GLYPH_FONT_SIZE);
                     free_glyph_atlas_measure_line_sized(
                         atlas, editor->data.items + line_chr.begin, select_begin_chr - line_chr.begin,
                         &select_begin_scr);
@@ -288,7 +288,7 @@ void editor_render(SDL_Window *window, Free_Glyph_Atlas *atlas, Simple_Renderer 
         size_t cursor_row = editor_cursor_row(editor);
         Line line = editor->lines.items[cursor_row];
         size_t cursor_col = editor->cursor - line.begin;
-        cursor_pos.y = -(float) cursor_row * FREE_GLYPH_FONT_SIZE;
+        cursor_pos.y = -((float)cursor_row + CURSOR_OFFSET) * FREE_GLYPH_FONT_SIZE;
         cursor_pos.x = free_glyph_atlas_cursor_pos(
                            atlas,
                            editor->data.items + line.begin, line.end - line.begin,

--- a/src/file_browser.c
+++ b/src/file_browser.c
@@ -67,7 +67,7 @@ void fb_render(const File_Browser *fb, SDL_Window *window, Free_Glyph_Atlas *atl
 
     simple_renderer_set_shader(sr, SHADER_FOR_COLOR);
     if (fb->cursor < fb->files.count) {
-        const Vec2f begin = vec2f(0, -(float)fb->cursor * FREE_GLYPH_FONT_SIZE);
+        const Vec2f begin = vec2f(0, -((float)fb->cursor + CURSOR_OFFSET) * FREE_GLYPH_FONT_SIZE);
         Vec2f end = begin;
         free_glyph_atlas_measure_line_sized(
             atlas, fb->files.items[fb->cursor], strlen(fb->files.items[fb->cursor]),


### PR DESCRIPTION
Adds an offset to the cursor and the selected text in editor mode, as well as the selected file in file browser mode.

The offset is a constant defined in `src/common.h` that is added to the `y` coordinate of the respective cursor when being rendered.