### PR TITLE
Add compile_commands.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ SDL2
 *.obj
 *.pdb
 *.ilk
+compile_commands.json


### PR DESCRIPTION
compiled_commands.json is useful for auto-complete.
This PR adds it to .gitignore 