### PR TITLE
Move bg out of the while (!quit) loop so it's not being recomputed every frame

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -160,6 +160,8 @@ int main(int argc, char **argv)
         fprintf(stderr, "WARNING: GLEW_ARB_debug_output is not available");
     }
 
+    Vec4f bg = hex_to_vec4f(0x181818FF);
+
     simple_renderer_init(&sr);
     free_glyph_atlas_init(&atlas, face);
 
@@ -357,7 +359,6 @@ int main(int argc, char **argv)
             glViewport(0, 0, w, h);
         }
 
-        Vec4f bg = hex_to_vec4f(0x181818FF);
         glClearColor(bg.x, bg.y, bg.z, bg.w);
         glClear(GL_COLOR_BUFFER_BIT);
 


### PR DESCRIPTION
Changes: src/main.c

Move the bg variable to above the while (!quit) loop since it was running hex_to_vec4f() every frame. The bg color doesn't change, so there is no need for it to be in the loop. It can just be computed once, before the loop