### PR TITLE
Declare fragment shader outputs

### DIFF
--- a/shaders/simple_color.frag
+++ b/shaders/simple_color.frag
@@ -2,6 +2,8 @@
 
 in vec4 out_color;
 
+out vec4 fragColor;
+
 void main() {
-    gl_FragColor = out_color;
+    fragColor = out_color;
 }

--- a/shaders/simple_epic.frag
+++ b/shaders/simple_epic.frag
@@ -6,6 +6,8 @@ uniform sampler2D image;
 
 in vec2 out_uv;
 
+out vec4 fragColor;
+
 vec3 hsl2rgb(vec3 c) {
     vec3 rgb = clamp(abs(mod(c.x*6.0+vec3(0.0,4.0,2.0),6.0)-3.0)-1.0, 0.0, 1.0);
     return c.z + c.y * (rgb-0.5)*(1.0-abs(2.0*c.z-1.0));
@@ -18,5 +20,5 @@ void main() {
     float alpha = smoothstep(0.5 - aaf, 0.5 + aaf, d);
     vec2 frag_uv = gl_FragCoord.xy / resolution;
     vec4 rainbow = vec4(hsl2rgb(vec3((time + frag_uv.x + frag_uv.y), 0.5, 0.5)), 1.0);
-    gl_FragColor = vec4(rainbow.rgb, alpha);
+    fragColor = vec4(rainbow.rgb, alpha);
 }

--- a/shaders/simple_image.frag
+++ b/shaders/simple_image.frag
@@ -4,6 +4,8 @@ uniform sampler2D image;
 
 in vec2 out_uv;
 
+out vec4 fragColor;
+
 void main() {
-    gl_FragColor = texture(image, out_uv);
+    fragColor = texture(image, out_uv);
 }

--- a/shaders/simple_text.frag
+++ b/shaders/simple_text.frag
@@ -5,9 +5,11 @@ uniform sampler2D image;
 in vec4 out_color;
 in vec2 out_uv;
 
+out vec4 fragColor;
+
 void main() {
     float d = texture(image, out_uv).r;
     float aaf = fwidth(d);
     float alpha = smoothstep(0.5 - aaf, 0.5 + aaf, d);
-    gl_FragColor = vec4(out_color.rgb, alpha);
+    fragColor = vec4(out_color.rgb, alpha);
 }


### PR DESCRIPTION
## Problem

The build went fine without warnings or errors on my Mac, but the shaders cannot be compiled:

```
❯ ./ded     
GL version 3.3
WARNING: GLEW_ARB_debug_output is not availableERROR: could not compile GL_FRAGMENT_SHADER
ERROR: 0:6: Use of undeclared identifier 'gl_FragColor'

ERROR: failed to compile `./shaders/simple_color.frag` shader file
```

Is the program written for a different GL version than what macOS 11.7.2 provides perhaps (see caveats)?

## Solution

Update each of the `shaders/simple_*.frag` programs to stop using `gl_FragColor`, instead declare `out vec4 fragColor;` and use that.

Compare for this fix in dlangui:

https://github.com/buggins/dlangui/commit/6cfe98a4f1f665887fc4c0cccd526a8ce9f3c19c#diff-0671d7c48bc6543434a3b3c9b6671be5b41902e679cfa0520fa7f0c780d670e4L231

## Caveats

I don't write many graphical programs. Perhaps macOS is always a pain and you don't want to support it. Given that build.sh contains a uname check for "Darwin" though, I'm giving it a shot.

I used the following versions of the dependencies (latest in Homebrew):

* sdl2 2.26.3
* freetype 2.13.0
* glew 2.2.0_1
