### PR TITLE
Fix last keystroke time not being updated on certain keys

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -237,7 +237,6 @@ int main(int argc, char **argv)
                     switch (event.key.keysym.sym) {
                     case SDLK_BACKSPACE: {
                         editor_backspace(&editor);
-                        editor.last_stroke = SDL_GetTicks();
                     }
                     break;
 
@@ -266,13 +265,11 @@ int main(int argc, char **argv)
 
                     case SDLK_RETURN: {
                         editor_insert_char(&editor, '\n');
-                        editor.last_stroke = SDL_GetTicks();
                     }
                     break;
 
                     case SDLK_DELETE: {
                         editor_delete(&editor);
-                        editor.last_stroke = SDL_GetTicks();
                     }
                     break;
 
@@ -316,14 +313,12 @@ int main(int argc, char **argv)
                     case SDLK_UP: {
                         editor_update_selection(&editor, event.key.keysym.mod & KMOD_SHIFT);
                         editor_move_line_up(&editor);
-                        editor.last_stroke = SDL_GetTicks();
                     }
                     break;
 
                     case SDLK_DOWN: {
                         editor_update_selection(&editor, event.key.keysym.mod & KMOD_SHIFT);
                         editor_move_line_down(&editor);
-                        editor.last_stroke = SDL_GetTicks();
                     }
                     break;
 
@@ -334,7 +329,6 @@ int main(int argc, char **argv)
                         } else {
                             editor_move_char_left(&editor);
                         }
-                        editor.last_stroke = SDL_GetTicks();
                     }
                     break;
 
@@ -345,10 +339,10 @@ int main(int argc, char **argv)
                         } else {
                             editor_move_char_right(&editor);
                         }
-                        editor.last_stroke = SDL_GetTicks();
                     }
                     break;
                     }
+					editor.last_stroke = SDL_GetTicks();
                 }
             }
             break;


### PR DESCRIPTION
I noticed that while pressing tab the cursor last keystroke was not being updated:

```c
case SDLK_TAB: {
    for (size_t i = 0; i < 4; ++i) {
        editor_insert_char(&editor, ' ');
    }
}
```

it should be:

```c
case SDLK_TAB: {
    for (size_t i = 0; i < 4; ++i) {
        editor_insert_char(&editor, ' ');
    }
    editor.last_stroke = SDL_GetTicks();
}
```

but instead of updating the last keystroke individually in every key press, it's better to update it when a key is pressed regardless if the key being pressed has a dedicated function or not.

This commit removes all the `editor.last_stroke = SDL_GetTicks();` from every key case and adds only one after the `switch` execution.