### PR TITLE
Add functionality to delete the selected area

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -43,6 +43,40 @@ void editor_delete(Editor *e)
     editor_retokenize(e);
 }
 
+void editor_delete_selection(Editor *e)
+{
+    assert(e->selection);
+
+    if (e->cursor > e->select_begin) {
+        if (e->cursor > e->data.count) {
+            e->cursor = e->data.count;
+        }
+        if (e->cursor == 0) return;
+
+        size_t nchars = e->cursor - e->select_begin;
+        memmove(
+            &e->data.items[e->cursor - nchars],
+            &e->data.items[e->cursor],
+            e->data.count - e->cursor
+        );
+
+        e->cursor -= nchars;
+        e->data.count -= nchars;
+    } else {
+        if (e->cursor >= e->data.count) return;
+
+        size_t nchars = e->select_begin - e->cursor;
+        memmove(
+            &e->data.items[e->cursor],
+            &e->data.items[e->cursor + nchars],
+            e->data.count - e->cursor - nchars
+        );
+
+        e->data.count -= nchars;
+    }
+    editor_retokenize(e);
+}
+
 // TODO: make sure that you always have new line at the end of the file while saving
 // https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_206
 

--- a/src/editor.h
+++ b/src/editor.h
@@ -52,6 +52,7 @@ Errno editor_load_from_file(Editor *editor, const char *file_path);
 
 void editor_backspace(Editor *editor);
 void editor_delete(Editor *editor);
+void editor_delete_selection(Editor *editor);
 size_t editor_cursor_row(const Editor *e);
 
 void editor_move_line_up(Editor *e);

--- a/src/main.c
+++ b/src/main.c
@@ -253,7 +253,12 @@ int main(int argc, char **argv)
                     } break;
 
                     case SDLK_BACKSPACE: {
-                        editor_backspace(&editor);
+                        if (editor.selection) {
+                            editor_delete_selection(&editor);
+                            editor.selection = false;
+                        } else {
+                            editor_backspace(&editor);
+                        }
                         editor.last_stroke = SDL_GetTicks();
                     }
                     break;
@@ -292,7 +297,12 @@ int main(int argc, char **argv)
                     break;
 
                     case SDLK_DELETE: {
-                        editor_delete(&editor);
+                        if (editor.selection) {
+                            editor_delete_selection(&editor);
+                            editor.selection = false;
+                        } else {
+                            editor_delete(&editor);
+                        }
                         editor.last_stroke = SDL_GetTicks();
                     }
                     break;


### PR DESCRIPTION
Single function `editor_delete_selection` in `editor.c` mimicking `editor_delete` and `editor_backspace` that deletes the entire selected area.