### PR TITLE
remove deprecated `gl_FragColor` api

### DIFF
--- a/ded.dSYM/Contents/Info.plist
+++ b/ded.dSYM/Contents/Info.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>CFBundleDevelopmentRegion</key>
+		<string>English</string>
+		<key>CFBundleIdentifier</key>
+		<string>com.apple.xcode.dsym.ded</string>
+		<key>CFBundleInfoDictionaryVersion</key>
+		<string>6.0</string>
+		<key>CFBundlePackageType</key>
+		<string>dSYM</string>
+		<key>CFBundleSignature</key>
+		<string>????</string>
+		<key>CFBundleShortVersionString</key>
+		<string>1.0</string>
+		<key>CFBundleVersion</key>
+		<string>1</string>
+	</dict>
+</plist>

--- a/shaders/simple_color.frag
+++ b/shaders/simple_color.frag
@@ -1,7 +1,9 @@
+
 #version 330 core
 
 in vec4 out_color;
+out vec4 FragColor;
 
 void main() {
-    gl_FragColor = out_color;
+    FragColor = out_color;
 }

--- a/shaders/simple_epic.frag
+++ b/shaders/simple_epic.frag
@@ -6,6 +6,8 @@ uniform sampler2D image;
 
 in vec2 out_uv;
 
+out vec4 out_color;
+
 vec3 hsl2rgb(vec3 c) {
     vec3 rgb = clamp(abs(mod(c.x*6.0+vec3(0.0,4.0,2.0),6.0)-3.0)-1.0, 0.0, 1.0);
     return c.z + c.y * (rgb-0.5)*(1.0-abs(2.0*c.z-1.0));
@@ -16,7 +18,7 @@ void main() {
     float d = tc.r;
     float aaf = fwidth(d);
     float alpha = smoothstep(0.5 - aaf, 0.5 + aaf, d);
-    vec2 frag_uv = gl_FragCoord.xy / resolution;
+    vec2 frag_uv = out_uv;
     vec4 rainbow = vec4(hsl2rgb(vec3((time + frag_uv.x + frag_uv.y), 0.5, 0.5)), 1.0);
-    gl_FragColor = vec4(rainbow.rgb, alpha);
+    out_color = vec4(rainbow.rgb, alpha);
 }

--- a/shaders/simple_image.frag
+++ b/shaders/simple_image.frag
@@ -3,7 +3,8 @@
 uniform sampler2D image;
 
 in vec2 out_uv;
+out vec4 FragColor;
 
 void main() {
-    gl_FragColor = texture(image, out_uv);
+    FragColor = texture(image, out_uv);
 }

--- a/shaders/simple_text.frag
+++ b/shaders/simple_text.frag
@@ -4,10 +4,16 @@ uniform sampler2D image;
 
 in vec4 out_color;
 in vec2 out_uv;
+out vec4 FragColor;
 
 void main() {
     float d = texture(image, out_uv).r;
     float aaf = fwidth(d);
     float alpha = smoothstep(0.5 - aaf, 0.5 + aaf, d);
-    gl_FragColor = vec4(out_color.rgb, alpha);
+    FragColor = vec4(out_color.rgb, alpha);
 }
+
+
+
+
+


### PR DESCRIPTION

## Changed shader code to remove deprecated `gl_FragColor` api

The changes made to the code are intended to fix a bug that was causing the following error messages to occur:

```bash
GL version 3.3
WARNING: GLEW_ARB_debug_output is not availableERROR: could not compile GL_FRAGMENT_SHADER
ERROR: 0:8: Use of undeclared identifier 'gl_FragColor'

ERROR: failed to compile `./shaders/simple_image.frag` shader file
```

```bash
GL version 3.3
WARNING: GLEW_ARB_debug_output is not availableERROR: could not compile GL_FRAGMENT_SHADER
ERROR: 0:12: Use of undeclared identifier 'gl_FragColor'

ERROR: failed to compile `./shaders/simple_text.frag` shader file
```

```bash
GL version 3.3
WARNING: GLEW_ARB_debug_output is not availableERROR: could not compile GL_FRAGMENT_SHADER
ERROR: 0:21: Use of undeclared identifier 'gl_FragColor'

ERROR: failed to compile `./shaders/simple_epic.frag` shader file
```

```bash
GL version 3.3
WARNING: GLEW_ARB_debug_output is not availableERROR: could not compile GL_FRAGMENT_SHADER
ERROR: 0:21: Use of undeclared identifier 'gl_FragColor'

ERROR: failed to compile `./shaders/simple_image.frag` shader file
```

### Summary of all the changes

The `simple_color.frag`, `simple_epic.frag`, `simple_image.frag`, and `simple_text.frag` files all underwent similar changes:

The API used to declare the output color variable `gl_FragColor` was deprecated, and the new API requires the use of an `out` variable. 

```glsl
from:
gl_FragColor = texture(image, out_uv); 

to:
out vec4 FragColor;
FragColor = texture(image, out_uv);
```


Thus, the `out` variables `FragColor` and `out_color` were declared in the modified files to replace the deprecated `gl_FragColor`. 

These changes ensure that the output color variables are properly declared and can be used in the code without throwing any errors. 

Additionally, in the `simple_epic.frag` file, the `frag_uv` variable was modified to use the `out_uv` variable instead of `gl_FragCoord.xy / resolution`. 

```glsl
from:
vec2 frag_uv = gl_FragCoord.xy / resolution;

to:
vec2 frag_uv = out_uv;
```
This change was made because `gl_FragCoord.xy / resolution` is deprecated in newer versions of OpenGL and may not be supported in future versions. 

Using `out_uv` ensures that the code is compatible with current and future versions of OpenGL. 
