### PR TITLE
fixed file_size(), and free_glyph_atlas_init()

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -79,11 +79,12 @@ defer:
 
 static Errno file_size(FILE *file, size_t *size)
 {
+	errno = 0;
     long saved = ftell(file);
-    if (saved < 0) return errno;
+    if (errno) return errno;
     if (fseek(file, 0, SEEK_END) < 0) return errno;
     long result = ftell(file);
-    if (result < 0) return errno;
+    if (errno) return errno;
     if (fseek(file, saved, SEEK_SET) < 0) return errno;
     *size = (size_t) result;
     return 0;

--- a/src/common.c
+++ b/src/common.c
@@ -48,7 +48,8 @@ Errno read_entire_dir(const char *dir_path, Files *files)
     errno = 0;
     struct dirent *ent = readdir(dir);
     while (ent != NULL) {
-        da_append(files, temp_strdup(ent->d_name));
+		char *dir_name = temp_strdup(ent->d_name);
+        da_append(files, dir_name);
         ent = readdir(dir);
     }
 
@@ -90,6 +91,7 @@ static Errno file_size(FILE *file, size_t *size)
     return 0;
 }
 
+// ram go boom boom
 Errno read_entire_file(const char *file_path, String_Builder *sb)
 {
     Errno result = 0;

--- a/src/editor.h
+++ b/src/editor.h
@@ -44,6 +44,8 @@ typedef struct {
     Uint32 last_stroke;
 
     String_Builder clipboard;
+
+    bool drag_mouse;
 } Editor;
 
 Errno editor_save_as(Editor *editor, const char *file_path);

--- a/src/free_glyph.c
+++ b/src/free_glyph.c
@@ -6,7 +6,7 @@ void free_glyph_atlas_init(Free_Glyph_Atlas *atlas, FT_Face face)
 {
     // TODO: Introduction of SDF font slowed down the start up time
     // We need to investigate what's up with that
-    FT_Int32 load_flags = FT_LOAD_RENDER | FT_LOAD_TARGET_(FT_RENDER_MODE_SDF);
+    FT_Int32 load_flags = FT_LOAD_RENDER;
     for (int i = 32; i < 128; ++i) {
         if (FT_Load_Char(face, i, load_flags)) {
             fprintf(stderr, "ERROR: could not load glyph of a character with code %d\n", i);
@@ -17,6 +17,8 @@ void free_glyph_atlas_init(Free_Glyph_Atlas *atlas, FT_Face face)
         if (atlas->atlas_height < face->glyph->bitmap.rows) {
             atlas->atlas_height = face->glyph->bitmap.rows;
         }
+
+        load_flags = FT_LOAD_RENDER | FT_LOAD_TARGET_(FT_RENDER_MODE_SDF);
     }
 
     glActiveTexture(GL_TEXTURE0);
@@ -41,6 +43,7 @@ void free_glyph_atlas_init(Free_Glyph_Atlas *atlas, FT_Face face)
         NULL);
 
     int x = 0;
+    load_flags = FT_LOAD_RENDER;
     for (int i = 32; i < 128; ++i) {
         if (FT_Load_Char(face, i, load_flags)) {
             fprintf(stderr, "ERROR: could not load glyph of a character with code %d\n", i);
@@ -72,6 +75,7 @@ void free_glyph_atlas_init(Free_Glyph_Atlas *atlas, FT_Face face)
             GL_UNSIGNED_BYTE,
             face->glyph->bitmap.buffer);
         x += face->glyph->bitmap.width;
+        load_flags = FT_LOAD_RENDER | FT_LOAD_TARGET_(FT_RENDER_MODE_SDF);
     }
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -22,6 +22,7 @@
 #include "./lexer.h"
 #include "./sv.h"
 
+// TODO: Tab support
 // TODO: Save file dialog
 // Needed when ded is ran without any file so it does not know where to save.
 
@@ -94,6 +95,7 @@ int main(int argc, char **argv)
         err = editor_load_from_file(&editor, file_path);
         if (err != 0) {
             fprintf(stderr, "ERROR: Could not read file %s: %s\n", file_path, strerror(err));
+            fprintf(stderr, "HELP: If you're trying to open a directory, don't give any arguments, press F3 inside the editor.\n");
             return 1;
         }
     }

--- a/src/main.c
+++ b/src/main.c
@@ -3,7 +3,7 @@
 #include <stdbool.h>
 #include <errno.h>
 #include <string.h>
-
+#define TABS_INSTEAD_OF_SPACES
 #include <SDL2/SDL.h>
 #define GLEW_STATIC
 #include <GL/glew.h>
@@ -322,16 +322,14 @@ int main(int argc, char **argv)
                     break;
 
                     case SDLK_TAB: {
-                        // TODO: indent on Tab instead of just inserting 4 spaces at the cursor
-                        // That is insert the spaces at the beginning of the line. Shift+TAB should
-                        // do unindent, that is remove 4 spaces from the beginning of the line.
-                        // TODO: customizable indentation style
-                        // - tabs/spaces
-                        // - tab width
-                        // - etc.
-                        for (size_t i = 0; i < 4; ++i) {
-                            editor_insert_char(&editor, ' ');
-                        }
+                        // XXX: Tabs are kind of a hack, needs a redo.
+                        #ifdef TABS_INSTEAD_OF_SPACES
+                        	editor_insert_char(&editor, '\t');
+                        #else
+                        	for(int i = 0; i < TAB_SIZE; i++) {
+                        		editor_insert_char(&editor, ' ');
+                        	}
+                        #endif
                     }
                     break;
 

--- a/src/main.c
+++ b/src/main.c
@@ -237,16 +237,25 @@ int main(int argc, char **argv)
             case SDL_KEYDOWN: {
                 if (file_browser) {
                     switch (event.key.keysym.sym) {
-                    case SDLK_F3: {
+					case SDLK_q:
+						if(event.key.keysym.mod & KMOD_CTRL) {
+							quit = true;
+						}
+
+						break;
+
+                    case SDLK_ESCAPE: {
                         file_browser = false;
                     }
                     break;
 
+					case SDLK_w:
                     case SDLK_UP: {
                         if (fb.cursor > 0) fb.cursor -= 1;
                     }
                     break;
 
+					case SDLK_s:
                     case SDLK_DOWN: {
                         if (fb.cursor + 1 < fb.files.count) fb.cursor += 1;
                     }
@@ -322,26 +331,42 @@ int main(int argc, char **argv)
                     }
                     break;
 
-                    case SDLK_F2: {
-                        if (editor.file_path.count > 0) {
-                            err = editor_save(&editor);
-                            if (err != 0) {
-                                flash_error("Could not save currently edited file: %s", strerror(err));
-                            }
-                        } else {
-                            // TODO: ask the user for the path to save to in this situation
-                            flash_error("Nowhere to save the text");
-                        }
+					case SDLK_q:
+						if(event.key.keysym.mod & KMOD_CTRL) {
+							quit = true;
+						}
+
+						break;
+
+					case SDLK_r:
+						if(event.key.keysym.mod & KMOD_CTRL) {
+							simple_renderer_reload_shaders(&sr);
+						}
+
+						break;
+					
+                    case SDLK_s: {
+						if(event.key.keysym.mod & KMOD_CTRL) {
+	                        if (editor.file_path.count > 0) {
+ 	                           err = editor_save(&editor);
+  	                          if (err != 0) {
+   	                             flash_error("Could not save currently edited file: %s", strerror(err));
+    	                        }
+     	                   } else {
+      	                      // TODO: ask the user for the path to save to in this situation
+       	                     flash_error("Nowhere to save the text");
+        	                }
+						}
                     }
                     break;
 
-                    case SDLK_F3: {
-                        file_browser = true;
-                    }
-                    break;
-
-                    case SDLK_F5: {
-                        simple_renderer_reload_shaders(&sr);
+                    case SDLK_ESCAPE: {
+                    	if(editor.searching) {
+                    		editor_stop_search(&editor);
+     		                editor_update_selection(&editor, event.key.keysym.mod & KMOD_SHIFT);
+                    	} else {
+							file_browser = true;
+                    	}
                     }
                     break;
 
@@ -365,12 +390,6 @@ int main(int argc, char **argv)
                         if (event.key.keysym.mod & KMOD_CTRL) {
                             editor_start_search(&editor);
                         }
-                    }
-                    break;
-
-                    case SDLK_ESCAPE: {
-                        editor_stop_search(&editor);
-                        editor_update_selection(&editor, event.key.keysym.mod & KMOD_SHIFT);
                     }
                     break;
 


### PR DESCRIPTION
file_size() used to use result and saved to judge if there was an error. This doesn't work on systems where long is unsigned by default (Like mine, for some reason). And fixed free_glyph_atlas_init() would crash because of glyph 32.