### PR TITLE
Implemented window specific behavior and fixed shader load

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -94,7 +94,7 @@ Errno read_entire_file(const char *file_path, String_Builder *sb)
     Errno result = 0;
     FILE *f = NULL;
 
-    f = fopen(file_path, "r");
+    f = fopen(file_path, "rb");
     if (f == NULL) return_defer(errno);
 
     size_t size;
@@ -133,7 +133,15 @@ Vec4f hex_to_vec4f(uint32_t color)
 Errno type_of_file(const char *file_path, File_Type *ft)
 {
 #ifdef _WIN32
-#error "TODO: type_of_file() is not implemented for Windows"
+	DWORD file_obj_type = GetFileAttributesA(file_path);
+	if (file_obj_type == FILE_ATTRIBUTE_DIRECTORY)
+	{
+		*ft = FT_DIRECTORY;
+	}
+	else
+	{
+		*ft = FT_OTHER;
+	}
 #else
     struct stat sb = {0};
     if (stat(file_path, &sb) < 0) return errno;

--- a/src/common.c
+++ b/src/common.c
@@ -134,9 +134,14 @@ Errno type_of_file(const char *file_path, File_Type *ft)
 {
 #ifdef _WIN32
 	DWORD file_obj_type = GetFileAttributesA(file_path);
-	if (file_obj_type == FILE_ATTRIBUTE_DIRECTORY)
+	if (file_obj_type & FILE_ATTRIBUTE_DIRECTORY)
 	{
 		*ft = FT_DIRECTORY;
+	}
+	// I have no idea why, but a 'normal' file is considered an archive file?
+	else if (file_obj_type & FILE_ATTRIBUTE_ARCHIVE)
+	{
+		*ft = FT_REGULAR;
 	}
 	else
 	{

--- a/src/simple_renderer.c
+++ b/src/simple_renderer.c
@@ -29,10 +29,11 @@ static const char *shader_type_as_cstr(GLuint shader)
     }
 }
 
-static bool compile_shader_source(const GLchar *source, GLenum shader_type, GLuint *shader)
+static bool compile_shader_source(const String_Builder source, GLenum shader_type, GLuint *shader)
 {
     *shader = glCreateShader(shader_type);
-    glShaderSource(*shader, 1, &source, NULL);
+    GLint source_count=(GLint)source.count;
+    glShaderSource(*shader, 1, &source.items, &source_count);
     glCompileShader(*shader);
 
     GLint compiled = 0;
@@ -62,7 +63,7 @@ static bool compile_shader_file(const char *file_path, GLenum shader_type, GLuin
     }
     sb_append_null(&source);
 
-    if (!compile_shader_source(source.items, shader_type, shader)) {
+    if (!compile_shader_source(source, shader_type, shader)) {
         fprintf(stderr, "ERROR: failed to compile `%s` shader file\n", file_path);
         return_defer(false);
     }


### PR DESCRIPTION
Implemented type_of_file for windows and fixed shader bug where it fails to compile on load

Description of bug:
Programs abnormally terminates when it is ran.

Explanation and Solution:
TLDR: Shader is not compiled properly due to garbage values. String is not terminated properly.

File is loaded as a text file, so \r\n gets translated to \n, meaning string count > characters read, leading to glShaderSource reading uninitialized memory on Windows. Also, null was passed to the last argument of glShaderSource meaning the string is read as a null terminated (was supposed to be a counted), fixed by passing String_Builder to pass .count. Still works (unexpectedly), but you shouldn't count the os to give you zeroed out memory (unless you use os specific calls that give you that, eg. VirtualAlloc). Following is a hex dump of both text and binary mode on Windows.

![nl](https://github.com/tsoding/ded/assets/86920804/0747a496-0b6e-4981-969e-33a51629c589)