### PR TITLE
Fixed build script that called C++ compiler instead of C compiler

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 set -xe
 
-CC="${CXX:-cc}"
+CC="${CC:-cc}"
 PKGS="sdl2 glew freetype2"
 CFLAGS="-Wall -Wextra -std=c11 -pedantic -ggdb"
 LIBS=-lm


### PR DESCRIPTION
The original build script uses `$CXX` (which is a variable that usually stands for a C++ compiler) to detect a **C** compiler, which may cause problems in some cases (for example my `$CXX` is set to `clang++` (actually `/opt/homebrew/opt/llvm/bin/clang++` but it doesn't matter), and when trying to pass `-std=c11` to `clang++` it will complain about that it cannot be used to compile C++. It could be solved by passing `-x c` to this specific compiler but it would be better to use C compiler though.).