### PR TITLE
Only commit successful directory changes

### DIFF
--- a/src/file_browser.c
+++ b/src/file_browser.c
@@ -105,26 +105,32 @@ Errno fb_change_dir(File_Browser *fb)
 
     const char *dir_name = fb->files.items[fb->cursor];
 
-    fb->dir_path.count -= 1;
+    String_Builder new_path = { 0 };
+    da_append_many(&new_path, fb->dir_path.items, fb->dir_path.count);
+
+    new_path.count -= 1;
 
     // TODO: fb->dir_path grows indefinitely if we hit the root
-    sb_append_cstr(&fb->dir_path, "/");
-    sb_append_cstr(&fb->dir_path, dir_name);
+    sb_append_cstr(&new_path, "/");
+    sb_append_cstr(&new_path, dir_name);
 
-    String_Builder result = {0};
-    normpath(sb_to_sv(fb->dir_path), &result);
-    da_move(&fb->dir_path, result);
-    sb_append_null(&fb->dir_path);
+    String_Builder result = { 0 };
+    normpath(sb_to_sv(new_path), &result);
+    da_move(&new_path, result);
+    sb_append_null(&new_path);
 
-    printf("Changed dir to %s\n", fb->dir_path.items);
-
-    fb->files.count = 0;
-    fb->cursor = 0;
-    Errno err = read_entire_dir(fb->dir_path.items, &fb->files);
-
+    Files new_files = { 0 };
+    Errno err = read_entire_dir(new_path.items, &new_files);
     if (err != 0) {
         return err;
     }
+
+    da_move(&fb->files, new_files);
+    da_move(&fb->dir_path, new_path);
+    fb->cursor = 0;
+
+    printf("Changed dir to %s\n", fb->dir_path.items);
+
     qsort(fb->files.items, fb->files.count, sizeof(*fb->files.items), file_cmp);
 
     return 0;


### PR DESCRIPTION
If you try to cd into a directory that you don't have permissions to open, the file browser would become blank with no way to recover since we had already changed the file browser state before knowing if the directory change would succeed.

This patch ensures that we only commit the directory change after we've successfully read it.