### PR TITLE
switch to sdl3

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Dependencies
 
-- [SDL2 2.0.9+](https://www.libsdl.org/)
+- [SDL3 3.0+](https://www.libsdl.org/)
 - [FreeType 2.13.0+](https://freetype.org/)
 - [GLEW 2.1.0+](https://glew.sourceforge.net/)
 

--- a/build.sh
+++ b/build.sh
@@ -3,9 +3,9 @@
 set -xe
 
 CC="${CXX:-cc}"
-PKGS="sdl2 glew freetype2"
+PKGS="glew freetype2"
 CFLAGS="-Wall -Wextra -std=c11 -pedantic -ggdb"
-LIBS=-lm
+LIBS="-lm -lSDL3"
 SRC="src/main.c src/la.c src/editor.c src/file_browser.c src/free_glyph.c src/simple_renderer.c src/common.c src/lexer.c"
 
 if [ `uname` = "Darwin" ]; then

--- a/build_msvc.bat
+++ b/build_msvc.bat
@@ -2,9 +2,9 @@
 rem launch this from msvc-enabled console
 
 set CFLAGS=/W4 /WX /std:c11 /wd4996 /wd5105 /FC /TC /Zi /nologo
-set INCLUDES=/I dependencies\SDL2\include /I dependencies\GLFW\include /I dependencies\GLEW\include
-set LIBS=dependencies\SDL2\lib\x64\SDL2.lib ^
-         dependencies\SDL2\lib\x64\SDL2main.lib ^
+set INCLUDES=/I dependencies\SDL3\include /I dependencies\GLFW\include /I dependencies\GLEW\include
+set LIBS=dependencies\SDL3\lib\x64\SDL3.lib ^
+         dependencies\SDL3\lib\x64\SDL3main.lib ^
          dependencies\GLFW\lib\glfw3.lib ^
          dependencies\GLEW\lib\glew32s.lib ^
          opengl32.lib User32.lib Gdi32.lib Shell32.lib

--- a/build_msys2_mingw64.sh
+++ b/build_msys2_mingw64.sh
@@ -2,7 +2,7 @@
 
 set -xe
 
-PKGS="--static sdl2 glew freetype2"
+PKGS="--static sdl3 glew freetype2"
 CFLAGS="-Wall -Wextra -pedantic -ggdb -DGLEW_STATIC `pkg-config --cflags $PKGS` -Isrc -Dassert(expression)=((void)0) "
 LIBS="-lm -lopengl32 `pkg-config --libs $PKGS`"
 SRC="src/main.c src/la.c src/editor.c src/file_browser.c src/free_glyph.c src/simple_renderer.c src/common.c"

--- a/setup_dependencies.bat
+++ b/setup_dependencies.bat
@@ -1,13 +1,13 @@
 @echo off
 
-curl -fsSL -o SDL2-devel-2.0.12-VC.zip https://www.libsdl.org/release/SDL2-devel-2.0.12-VC.zip
-tar -xf SDL2-devel-2.0.12-VC.zip
+curl -fsSL -o SDL3-devel-2.0-VC.zip https://www.libsdl.org/release/SDL3-devel-3.0-VC.zip
+tar -xf SDL3-devel-2.0-VC.zip
 if not exist dependencies\ mkdir dependencies\
-move SDL2-2.0.12 dependencies\SDL2
-del SDL2-devel-2.0.12-VC.zip
-if not exist dependencies\SDL2\temp\ mkdir dependencies\SDL2\temp\
-move dependencies\SDL2\include dependencies\SDL2\temp\SDL2
-move dependencies\SDL2\temp dependencies\SDL2\include
+move SDL3-3.0 dependencies\SDL3
+del SDL3-devel-3.0-VC.zip
+if not exist dependencies\SDL3\temp\ mkdir dependencies\SDL3\temp\
+move dependencies\SDL3\include dependencies\SDL3\temp\SDL3
+move dependencies\SDL3\temp dependencies\SDL3\include
 
 curl -fsSL -o glfw-3.3.2.bin.WIN64.zip https://github.com/glfw/glfw/releases/download/3.3.2/glfw-3.3.2.bin.WIN64.zip
 tar -xf glfw-3.3.2.bin.WIN64.zip

--- a/src/editor.c
+++ b/src/editor.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>
+#include <ctype.h>
 #include "./editor.h"
 #include "./common.h"
 

--- a/src/editor.h
+++ b/src/editor.h
@@ -7,7 +7,7 @@
 #include "simple_renderer.h"
 #include "lexer.h"
 
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 
 typedef struct {
     size_t begin;

--- a/src/file_browser.c
+++ b/src/file_browser.c
@@ -1,4 +1,5 @@
 #include <string.h>
+#include <math.h>
 #include "file_browser.h"
 #include "sv.h"
 

--- a/src/file_browser.h
+++ b/src/file_browser.h
@@ -4,7 +4,7 @@
 #include "common.h"
 #include "free_glyph.h"
 
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 
 typedef struct {
     Files files;

--- a/src/free_glyph.h
+++ b/src/free_glyph.h
@@ -8,7 +8,7 @@
 #include <GL/glew.h>
 
 #define GL_GLEXT_PROTOTYPES
-#include <SDL2/SDL_opengl.h>
+#include <SDL3/SDL_opengl.h>
 
 #include <ft2build.h>
 #include FT_FREETYPE_H

--- a/src/main.c
+++ b/src/main.c
@@ -4,11 +4,11 @@
 #include <errno.h>
 #include <string.h>
 
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #define GLEW_STATIC
 #include <GL/glew.h>
 #define GL_GLEXT_PROTOTYPES
-#include <SDL2/SDL_opengl.h>
+#include <SDL3/SDL_opengl.h>
 
 #include <ft2build.h>
 #include FT_FREETYPE_H
@@ -110,9 +110,7 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    SDL_Window *window =
-        SDL_CreateWindow("ded",
-                         0, 0,
+    SDL_Window *window = SDL_CreateWindow("ded",
                          SCREEN_WIDTH, SCREEN_HEIGHT,
                          SDL_WINDOW_RESIZABLE | SDL_WINDOW_OPENGL);
     if (window == NULL) {
@@ -159,6 +157,8 @@ int main(int argc, char **argv)
     editor.atlas = &atlas;
     editor_retokenize(&editor);
 
+    SDL_StartTextInput();
+
     bool quit = false;
     bool file_browser = false;
     while (!quit) {
@@ -166,12 +166,12 @@ int main(int argc, char **argv)
         SDL_Event event = {0};
         while (SDL_PollEvent(&event)) {
             switch (event.type) {
-            case SDL_QUIT: {
+            case SDL_EVENT_QUIT: {
                 quit = true;
             }
             break;
 
-            case SDL_KEYDOWN: {
+            case SDL_EVENT_KEY_DOWN: {
                 if (file_browser) {
                     switch (event.key.keysym.sym) {
                     case SDLK_F3: {
@@ -234,8 +234,8 @@ int main(int argc, char **argv)
                 } else {
                     switch (event.key.keysym.sym) {
                     case SDLK_HOME: {
-                        editor_update_selection(&editor, event.key.keysym.mod & KMOD_SHIFT);
-                        if (event.key.keysym.mod & KMOD_CTRL) {
+                        editor_update_selection(&editor, event.key.keysym.mod & SDL_KMOD_SHIFT);
+                        if (event.key.keysym.mod & SDL_KMOD_CTRL) {
                             editor_move_to_begin(&editor);
                         } else {
                             editor_move_to_line_begin(&editor);
@@ -244,8 +244,8 @@ int main(int argc, char **argv)
                     } break;
 
                     case SDLK_END: {
-                        editor_update_selection(&editor, event.key.keysym.mod & KMOD_SHIFT);
-                        if (event.key.keysym.mod & KMOD_CTRL) {
+                        editor_update_selection(&editor, event.key.keysym.mod & SDL_KMOD_SHIFT);
+                        if (event.key.keysym.mod & SDL_KMOD_CTRL) {
                             editor_move_to_end(&editor);
                         } else {
                             editor_move_to_line_end(&editor);
@@ -299,7 +299,7 @@ int main(int argc, char **argv)
                     break;
 
                     case SDLK_f: {
-                        if (event.key.keysym.mod & KMOD_CTRL) {
+                        if (event.key.keysym.mod & SDL_KMOD_CTRL) {
                             editor_start_search(&editor);
                         }
                     }
@@ -307,12 +307,12 @@ int main(int argc, char **argv)
 
                     case SDLK_ESCAPE: {
                         editor_stop_search(&editor);
-                        editor_update_selection(&editor, event.key.keysym.mod & KMOD_SHIFT);
+                        editor_update_selection(&editor, event.key.keysym.mod & SDL_KMOD_SHIFT);
                     }
                     break;
 
                     case SDLK_a: {
-                        if (event.key.keysym.mod & KMOD_CTRL) {
+                        if (event.key.keysym.mod & SDL_KMOD_CTRL) {
                             editor.selection = true;
                             editor.select_begin = 0;
                             editor.cursor = editor.data.count;
@@ -335,22 +335,22 @@ int main(int argc, char **argv)
                     break;
 
                     case SDLK_c: {
-                        if (event.key.keysym.mod & KMOD_CTRL) {
+                        if (event.key.keysym.mod & SDL_KMOD_CTRL) {
                             editor_clipboard_copy(&editor);
                         }
                     }
                     break;
 
                     case SDLK_v: {
-                        if (event.key.keysym.mod & KMOD_CTRL) {
+                        if (event.key.keysym.mod & SDL_KMOD_CTRL) {
                             editor_clipboard_paste(&editor);
                         }
                     }
                     break;
 
                     case SDLK_UP: {
-                        editor_update_selection(&editor, event.key.keysym.mod & KMOD_SHIFT);
-                        if (event.key.keysym.mod & KMOD_CTRL) {
+                        editor_update_selection(&editor, event.key.keysym.mod & SDL_KMOD_SHIFT);
+                        if (event.key.keysym.mod & SDL_KMOD_CTRL) {
                             editor_move_paragraph_up(&editor);
                         } else {
                             editor_move_line_up(&editor);
@@ -360,8 +360,8 @@ int main(int argc, char **argv)
                     break;
 
                     case SDLK_DOWN: {
-                        editor_update_selection(&editor, event.key.keysym.mod & KMOD_SHIFT);
-                        if (event.key.keysym.mod & KMOD_CTRL) {
+                        editor_update_selection(&editor, event.key.keysym.mod & SDL_KMOD_SHIFT);
+                        if (event.key.keysym.mod & SDL_KMOD_CTRL) {
                             editor_move_paragraph_down(&editor);
                         } else {
                             editor_move_line_down(&editor);
@@ -371,8 +371,8 @@ int main(int argc, char **argv)
                     break;
 
                     case SDLK_LEFT: {
-                        editor_update_selection(&editor, event.key.keysym.mod & KMOD_SHIFT);
-                        if (event.key.keysym.mod & KMOD_CTRL) {
+                        editor_update_selection(&editor, event.key.keysym.mod & SDL_KMOD_SHIFT);
+                        if (event.key.keysym.mod & SDL_KMOD_CTRL) {
                             editor_move_word_left(&editor);
                         } else {
                             editor_move_char_left(&editor);
@@ -382,8 +382,8 @@ int main(int argc, char **argv)
                     break;
 
                     case SDLK_RIGHT: {
-                        editor_update_selection(&editor, event.key.keysym.mod & KMOD_SHIFT);
-                        if (event.key.keysym.mod & KMOD_CTRL) {
+                        editor_update_selection(&editor, event.key.keysym.mod & SDL_KMOD_SHIFT);
+                        if (event.key.keysym.mod & SDL_KMOD_CTRL) {
                             editor_move_word_right(&editor);
                         } else {
                             editor_move_char_right(&editor);
@@ -396,7 +396,7 @@ int main(int argc, char **argv)
             }
             break;
 
-            case SDL_TEXTINPUT: {
+            case SDL_EVENT_TEXT_INPUT: {
                 if (file_browser) {
                     // Nothing for now
                     // Once we have incremental search in the file browser this may become useful

--- a/src/simple_renderer.h
+++ b/src/simple_renderer.h
@@ -7,7 +7,7 @@
 #include <GL/glew.h>
 
 #define GL_GLEXT_PROTOTYPES
-#include <SDL2/SDL_opengl.h>
+#include <SDL3/SDL_opengl.h>
 
 #include "./la.h"
 


### PR DESCRIPTION
This fix is part of an ongoing effort to improve stability and performance. I decided to upgrade the SDL version from 2.x.x (I don't remember anymore) to 3.0.

Why? Because we all know that SDL 3.0 is the future. It is faster, more stable and has better graphics. In addition, it forces programmers to reach for the "_" button more often (SDL_QUIT -> SDL_EVENT_QUIT), which can weed out fake programmers without dvorak (for example, me)

So go ahead and try it. You will not be disappointed. And if you do, blame it on the imperfection of our world in front of sdl3.